### PR TITLE
Add SwiftUI social media app skeleton

### DIFF
--- a/SocialRange/Models/Message.swift
+++ b/SocialRange/Models/Message.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Message: Identifiable, Codable {
+    let id: UUID
+    let senderID: UUID
+    let recipientID: UUID
+    var content: String
+    var createdAt: Date
+}

--- a/SocialRange/Models/Post.swift
+++ b/SocialRange/Models/Post.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct Post: Identifiable, Codable {
+    let id: UUID
+    let authorID: UUID
+    var content: String
+    var createdAt: Date
+    var location: Location
+    var rangeInKilometers: Double
+}
+
+struct Comment: Identifiable, Codable {
+    let id: UUID
+    let postID: UUID
+    let authorID: UUID
+    var content: String
+    var createdAt: Date
+}

--- a/SocialRange/Models/User.swift
+++ b/SocialRange/Models/User.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct User: Identifiable, Codable {
+    let id: UUID
+    var email: String
+    var profile: Profile
+    var location: Location?
+}
+
+struct Profile: Codable {
+    var name: String
+    var bio: String
+    var avatarURL: URL?
+}
+
+struct Location: Codable {
+    var latitude: Double
+    var longitude: Double
+}

--- a/SocialRange/SocialRangeApp.swift
+++ b/SocialRange/SocialRangeApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct SocialRangeApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SocialRange/ViewModels/MessageViewModel.swift
+++ b/SocialRange/ViewModels/MessageViewModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Combine
+
+class MessageViewModel: ObservableObject {
+    @Published var conversations: [UUID: [Message]] = [:]
+    private var cancellables = Set<AnyCancellable>()
+
+    func sendMessage(to recipientID: UUID, content: String) {
+        // TODO: Send message to server
+    }
+
+    func loadMessages(with userID: UUID) {
+        // TODO: Load messages from server
+    }
+}

--- a/SocialRange/ViewModels/PostViewModel.swift
+++ b/SocialRange/ViewModels/PostViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Combine
+import CoreLocation
+
+class PostViewModel: ObservableObject {
+    @Published var posts: [Post] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    func loadFeed(for location: CLLocation) {
+        // TODO: Load posts from server based on location
+    }
+
+    func createPost(content: String, location: CLLocation, range: Double) {
+        // TODO: Create post on server
+    }
+
+    func addComment(post: Post, content: String) {
+        // TODO: Create comment on server
+    }
+}

--- a/SocialRange/ViewModels/UserViewModel.swift
+++ b/SocialRange/ViewModels/UserViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Combine
+
+class UserViewModel: ObservableObject {
+    @Published var currentUser: User?
+    private var cancellables = Set<AnyCancellable>()
+
+    func login(email: String, password: String) {
+        // TODO: Implement authentication
+    }
+
+    func register(email: String, password: String) {
+        // TODO: Implement registration
+    }
+
+    func updateLocation(_ location: Location) {
+        // TODO: Send location to server
+    }
+}

--- a/SocialRange/Views/ContentView.swift
+++ b/SocialRange/Views/ContentView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        NavigationView {
+            LoginView()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SocialRange/Views/CreatePostView.swift
+++ b/SocialRange/Views/CreatePostView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import CoreLocation
+
+struct CreatePostView: View {
+    @State private var content: String = ""
+    @State private var rangeText: String = "5"
+    @State private var locationManager = CLLocationManager()
+    @State private var currentLocation: CLLocation?
+    @Environment(\.dismiss) var dismiss
+    @StateObject var postVM = PostViewModel()
+
+    var body: some View {
+        Form {
+            Section(header: Text("Content")) {
+                TextField("What do you want to do?", text: $content)
+            }
+            Section(header: Text("Visibility Range (km)")) {
+                TextField("Range", text: $rangeText)
+                    .keyboardType(.decimalPad)
+            }
+            Button("Post") {
+                if let location = locationManager.location,
+                   let range = Double(rangeText) {
+                    postVM.createPost(content: content, location: location, range: range)
+                    dismiss()
+                }
+            }
+        }
+        .navigationTitle("New Post")
+        .onAppear {
+            locationManager.requestWhenInUseAuthorization()
+            currentLocation = locationManager.location
+        }
+    }
+}
+
+struct CreatePostView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView { CreatePostView() }
+    }
+}

--- a/SocialRange/Views/FeedView.swift
+++ b/SocialRange/Views/FeedView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import CoreLocation
+
+struct FeedView: View {
+    @StateObject var postVM = PostViewModel()
+    @State private var locationManager = CLLocationManager()
+    @State private var currentLocation: CLLocation?
+
+    var body: some View {
+        List(postVM.posts) { post in
+            NavigationLink(destination: PostDetailView(post: post)) {
+                PostRow(post: post)
+            }
+        }
+        .navigationTitle("Feed")
+        .toolbar {
+            NavigationLink(destination: CreatePostView()) {
+                Image(systemName: "plus")
+            }
+        }
+        .onAppear {
+            locationManager.requestWhenInUseAuthorization()
+            currentLocation = locationManager.location
+            if let loc = currentLocation {
+                postVM.loadFeed(for: loc)
+            }
+        }
+    }
+}
+
+struct PostRow: View {
+    let post: Post
+    @State private var distanceText: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(post.content)
+            Text(distanceText)
+                .font(.footnote)
+                .foregroundColor(.gray)
+        }
+        .onAppear {
+            // compute distance without revealing author location
+            if let userLocation = CLLocationManager().location {
+                let postLocation = CLLocation(latitude: post.location.latitude,
+                                             longitude: post.location.longitude)
+                let distance = userLocation.distance(from: postLocation) / 1000
+                distanceText = String(format: "%.1f km away", distance)
+            }
+        }
+    }
+}
+
+struct FeedView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            FeedView()
+        }
+    }
+}

--- a/SocialRange/Views/LoginView.swift
+++ b/SocialRange/Views/LoginView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var showRegister: Bool = false
+    @State private var isLoggedIn: Bool = false
+
+    var body: some View {
+        VStack {
+            TextField("Email", text: $email)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            SecureField("Password", text: $password)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            Button("Login") {
+                // handle login
+                isLoggedIn = true
+            }
+            Button("Create Account") {
+                showRegister = true
+            }
+            .sheet(isPresented: $showRegister) {
+                RegisterView()
+            }
+            NavigationLink("", destination: MainTabView(), isActive: $isLoggedIn)
+                .hidden()
+        }
+        .padding()
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}

--- a/SocialRange/Views/MainTabView.swift
+++ b/SocialRange/Views/MainTabView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            NavigationView { FeedView() }
+                .tabItem {
+                    Label("Feed", systemImage: "list.bullet")
+                }
+            NavigationView { MessageListView() }
+                .tabItem {
+                    Label("Messages", systemImage: "bubble.left.and.bubble.right")
+                }
+            NavigationView {
+                if let user = UserViewModel().currentUser {
+                    ProfileView(user: user)
+                } else {
+                    Text("No profile")
+                }
+            }
+                .tabItem {
+                    Label("Profile", systemImage: "person")
+                }
+        }
+    }
+}
+
+struct MainTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabView()
+    }
+}

--- a/SocialRange/Views/MessageListView.swift
+++ b/SocialRange/Views/MessageListView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct MessageListView: View {
+    @StateObject var messageVM = MessageViewModel()
+    var body: some View {
+        List {
+            ForEach(messageVM.conversations.keys.sorted(), id: \.
+self) { userID in
+                NavigationLink(destination: ConversationView(userID: userID)) {
+                    Text("Conversation with \(userID.uuidString.prefix(6))")
+                }
+            }
+        }
+        .navigationTitle("Messages")
+        .onAppear {
+            // TODO: load conversation list
+        }
+    }
+}
+
+struct ConversationView: View {
+    @StateObject var messageVM = MessageViewModel()
+    let userID: UUID
+    @State private var messageText: String = ""
+
+    var body: some View {
+        VStack {
+            List(messageVM.conversations[userID] ?? []) { message in
+                Text(message.content)
+            }
+            HStack {
+                TextField("Message", text: $messageText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Send") {
+                    messageVM.sendMessage(to: userID, content: messageText)
+                    messageText = ""
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Chat")
+        .onAppear {
+            messageVM.loadMessages(with: userID)
+        }
+    }
+}
+
+struct MessageListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            MessageListView()
+        }
+    }
+}

--- a/SocialRange/Views/PostDetailView.swift
+++ b/SocialRange/Views/PostDetailView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct PostDetailView: View {
+    let post: Post
+    @State private var commentText: String = ""
+    @StateObject var postVM = PostViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(post.content)
+                .font(.title)
+            Text("Comments")
+                .font(.headline)
+            List {
+                // TODO: show comments
+            }
+            HStack {
+                TextField("Add a comment", text: $commentText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Send") {
+                    postVM.addComment(post: post, content: commentText)
+                    commentText = ""
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Post")
+    }
+}
+
+struct PostDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostDetailView(post: Post(id: UUID(), authorID: UUID(), content: "Test", createdAt: Date(), location: Location(latitude: 0, longitude: 0), rangeInKilometers: 5))
+    }
+}

--- a/SocialRange/Views/ProfileView.swift
+++ b/SocialRange/Views/ProfileView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var user: User
+
+    var body: some View {
+        VStack {
+            if let url = user.profile.avatarURL {
+                // TODO: load image from URL
+                Image(systemName: "person.crop.circle")
+            } else {
+                Image(systemName: "person.crop.circle")
+            }
+            Text(user.profile.name)
+                .font(.title)
+            Text(user.profile.bio)
+        }
+        .navigationTitle("Profile")
+    }
+}
+
+struct ProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        let user = User(id: UUID(), email: "test@example.com", profile: Profile(name: "Test", bio: "Bio", avatarURL: nil), location: nil)
+        ProfileView(user: user)
+    }
+}

--- a/SocialRange/Views/RegisterView.swift
+++ b/SocialRange/Views/RegisterView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct RegisterView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var confirmPassword: String = ""
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack {
+            TextField("Email", text: $email)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            SecureField("Password", text: $password)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            SecureField("Confirm Password", text: $confirmPassword)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+            Button("Register") {
+                // handle registration
+                dismiss()
+            }
+        }
+        .padding()
+    }
+}
+
+struct RegisterView_Previews: PreviewProvider {
+    static var previews: some View {
+        RegisterView()
+    }
+}


### PR DESCRIPTION
## Summary
- create a `SocialRange` SwiftUI app skeleton
- define basic models for users, posts, comments, and messages
- add view models with stubs for network operations
- implement login/registration views and a tabbed interface
- add feed with distance calculation and ability to create posts
- provide basic profile and messaging views

## Testing
- `swiftc SocialRange/SocialRangeApp.swift ...` *(fails: no such module 'SwiftUI')*